### PR TITLE
Check the av engine is running

### DIFF
--- a/service.rb
+++ b/service.rb
@@ -25,8 +25,12 @@ module Service
       end
     end
 
-    # Assumes the AVENGINE responds to --version and returns stderr if not running
-    check_avengine "#{ENV['AVENGINE']} --version"
+    if ENV['AVENGINE'] == 'clamdscan'
+      `ps aux`.include?('clamd')
+    else
+      # Assumes the AVENGINE responds to --version and returns stderr if not running
+      check_avengine "#{ENV['AVENGINE']} --version"
+    end
 
     rescue_from ActiveRecord::RecordNotFound do |e|
       rack_response({error: "These aren't the droids you're looking for..."}.to_json, 404)


### PR DESCRIPTION
clamdscan requires clamd to be running, does not return an error only outputs
the warning on stderr hence why we need to also check for that

assumes that engine accepts `--version` option 
