### PR TITLE
Removed auth-hash header

### DIFF
--- a/app/controllers/authorizations/client_authorization.rb
+++ b/app/controllers/authorizations/client_authorization.rb
@@ -8,24 +8,12 @@ class ClientAuthorization < BaseAuthorization
   end
 
   def authenticated?
-    current_project.present? && valid_hash?
+    current_project.present?
   end
 
 private
 
-  def valid_hash?
-    authorization_hash == digest(request.raw_post, current_project.secret_access_key)
-  end
-
   def authorization_token
     request.headers["Auth-Key"]
-  end
-
-  def authorization_hash
-    request.headers["Auth-Hash"]
-  end
-
-  def digest(body, secret_access_key)
-    Digest::MD5.hexdigest("#{body}#{secret_access_key}")
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe ProjectsController, type: :controller do
 
     before do
       request.headers["Auth-Key"] = current_project.access_key_id
-      allow_any_instance_of(ClientAuthorization).to receive(:valid_hash?).and_return(true)
     end
 
     describe "GET #validate" do

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe ScansController, type: :controller do
 
   before do
     request.headers["Auth-Key"] = current_project.access_key_id
-    allow_any_instance_of(ClientAuthorization).to receive(:valid_hash?).and_return(true)
   end
 
   describe "GET #index" do

--- a/spec/requests/scans_spec.rb
+++ b/spec/requests/scans_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Scans", type: :request do
 
   describe "GET /scans" do
     it "works!" do
-      allow_any_instance_of(ClientAuthorization).to receive(:valid_hash?).and_return(true)
       get scans_path, {}, "Auth-Key" => current_project.access_key_id
       expect(response).to have_http_status(200)
     end


### PR DESCRIPTION
removed Auth-Hash verification of client requests to make it easier for the client to integrate with vigilion. It still sends Auth-Hash for callback responses.

the Auth-Key header still works as ID of the project. but we no longer require an Auth-Hash.
