### PR TITLE
allow multiple av scanners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,4 @@
 FROM bitzesty/vigilion-scanner-baseimage:release-1.0
+
+# so that we sync in dev
+COPY . /usr/src/app

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,4 +1,5 @@
 class Plan < ActiveRecord::Base
+  ENGINES = [:clamav, :eset, :avg]
   MEGA_BYTE = 1024 * 1024
 
   has_many :accounts
@@ -11,5 +12,9 @@ class Plan < ActiveRecord::Base
 
   def allow_file_size?(size_in_bytes)
     file_size_limit.nil? || file_size_limit * MEGA_BYTE >= size_in_bytes
+  end
+
+  def engines
+    ENGINES.select { |e| public_send(e) }
   end
 end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -1,7 +1,12 @@
 class Scan < ActiveRecord::Base
+  AV_STATUSES = %w(pending scanning clean infected error)
   attr_accessor :file
 
-  enum status: %w(pending scanning clean infected error)
+  enum status: AV_STATUSES
+  enum clamav_status: AV_STATUSES, _prefix: :clamav
+  enum avg_status: AV_STATUSES, _prefix: :avg
+  enum eset_status: AV_STATUSES, _prefix: :eset
+
   belongs_to :project
   has_one :account, through: :project
 
@@ -38,14 +43,48 @@ class Scan < ActiveRecord::Base
     save!
   end
 
-  def complete! status, result
+  def av_checked!(scan_results)
+    scan_results.each do |engine, result|
+      self.public_send(
+        "#{engine}_status=",
+        result[:status]
+      )
+      self.public_send(
+        "#{engine}_result=",
+        result[:message]
+      )
+    end
+
+    result = relevant_result(scan_results)
+    complete!(result[:status], result[:message])
+  end
+
+  def complete!(status, result)
     self.status = status
     self.result = result
     self.ended_at = Time.now
     save!
   end
 
+  def engines
+    account.plan.engines
+  end
+
   private
+
+  def relevant_result(scan_results)
+    infected = scan_results.values.detect do |result|
+      result[:status] == :infected
+    end
+    return infected if infected.present?
+
+    clean = scan_results.values.detect do |result|
+      result[:status] == :clean
+    end
+    return clean if clean.present?
+
+    return scan_results.values.first
+  end
 
   def file_to_write?
     @file.present?

--- a/app/services/av_runner.rb
+++ b/app/services/av_runner.rb
@@ -3,18 +3,17 @@ require "open3"
 class AvRunner
   def perform(scan)
     set_checksums_and_file_size scan
-    unless cache_hit(scan)
-      Open3.popen3("#{CONFIG[:av_engine]} #{scan.file_path}") do |_, stdout, _, wait_thr|
-        message = message_from_clamav(stdout)
-        status = status_from_clamav(wait_thr)
-        Sidekiq.logger.info "Message: #{message}"
-        Sidekiq.logger.info "Status #{status}"
-        scan.complete! status, message
-      end
+
+    scan_results = scan.engines.inject({}) do |memo, engine|
+      engine_class = "AvRunner::#{engine.to_s.camelize}".constantize
+      memo[engine] = engine_class.new(scan).perform!
+      memo
     end
+
+    scan.av_checked! scan_results
   end
 
-private
+  private
 
   def set_checksums_and_file_size(scan)
     md5 = Digest::MD5.file(scan.file_path).hexdigest
@@ -22,28 +21,5 @@ private
     sha256 = Digest::SHA256.file(scan.file_path).hexdigest
     file_size = File.size(scan.file_path)
     scan.update!(md5: md5, sha1: sha1, sha256: sha256, file_size: file_size)
-  end
-
-  def cache_hit(scan)
-    return false if scan.force?
-    similar_scan = Scan.where(md5: scan.md5).
-      where("ended_at > ?", 30.days.ago).
-      where("id != ?", scan.id).
-      where("status != 4").
-      last
-    if similar_scan
-      scan.complete! similar_scan.status, "CACHE HIT: Similar scan performed"
-    end
-  end
-
-  def status_from_clamav(wait_thr)
-    exit_status = wait_thr.value.exitstatus
-    { 0 => :clean, 1 => :infected, 2 => :error }[exit_status]
-  end
-
-  def message_from_clamav(stdout)
-    first_line = stdout.read.split("\n")[0]
-    # Strip filepath out of message
-    first_line.gsub(/.*: /im, '')
   end
 end

--- a/app/services/av_runner/av_base.rb
+++ b/app/services/av_runner/av_base.rb
@@ -1,0 +1,49 @@
+class AvRunner::AvBase
+  attr_reader :scan
+
+  def initialize(scan)
+    @scan = scan
+  end
+
+  def perform!
+    if result = cache_hit(scan)
+      result
+    else
+      Open3.popen3("#{CONFIG[:engines][engine]} #{scan.file_path}") do |_, stdout, _, wait_thr|
+        message = extract_message(stdout)
+        status = extract_status(wait_thr)
+        Sidekiq.logger.info "[#{engine_name}] Message: #{message}"
+        Sidekiq.logger.info "[#{engine_name}] Status #{status}"
+
+        { status: status, message: message }
+     end
+    end
+  end
+
+  def cache_hit(scan)
+    return false if scan.force?
+    similar_scan = Scan.where(md5: scan.md5).
+      where("ended_at > ?", 30.days.ago).
+      where("id != ?", scan.id).
+      where("#{engine}_status != 4").
+      last
+    if similar_scan
+      { status: similar_scan.status, message: "CACHE HIT: Similar scan performed" }
+    end
+  end
+
+  def engine
+    raise NotImplementedError
+  end
+
+  def engine_name
+    engine.to_s.upcase
+  end
+  def extract_message(stdout)
+    raise NotImplementedError
+  end
+
+  def extract_status(wait_thr)
+    raise NotImplementedError
+  end
+end

--- a/app/services/av_runner/clamav.rb
+++ b/app/services/av_runner/clamav.rb
@@ -1,0 +1,18 @@
+class AvRunner::Clamav < AvRunner::AvBase
+  def engine
+    :clamav
+  end
+
+  private
+
+  def extract_message(stdout)
+    first_line = stdout.read.split("\n")[0]
+    # Strip filepath out of message
+    first_line.gsub(/.*: /im, '')
+  end
+
+  def extract_status(wait_thr)
+    exit_status = wait_thr.value.exitstatus
+    { 0 => :clean, 1 => :infected, 2 => :error }[exit_status]
+  end
+end

--- a/app/services/file_downloader.rb
+++ b/app/services/file_downloader.rb
@@ -4,7 +4,7 @@ class FileDownloader
   def download(scan)
     scan.file_exists? || download_file(scan)
   rescue DownloadError => error
-    scan.complete! :error, "Cannot download file. #{error.message}"
+    scan.complete!(:error, "Cannot download file. #{error.message}")
     false
   end
 

--- a/app/views/scans/_scan.json.jbuilder
+++ b/app/views/scans/_scan.json.jbuilder
@@ -1,0 +1,11 @@
+json.extract! scan,
+              :id,
+              :url,
+              :key,
+              :created_at,
+              :status,
+              :result,
+              :duration,
+              :response_time,
+              :file_size,
+              :engines

--- a/app/views/scans/index.json.jbuilder
+++ b/app/views/scans/index.json.jbuilder
@@ -1,3 +1,1 @@
-json.array!(@scans) do |scan|
-  json.extract! scan, :id, :url, :key, :created_at, :status, :result, :duration, :response_time, :file_size
-end
+json.array! @scans, partial: "scan", as: :scan

--- a/app/views/scans/show.json.jbuilder
+++ b/app/views/scans/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @scan, :id, :url, :key, :created_at, :status, :result, :duration, :response_time, :file_size
+json.partial! "scan", scan: @scan

--- a/config/config.yml
+++ b/config/config.yml
@@ -3,20 +3,32 @@ default: &default
 
 development:
   <<: *default
-  av_engine: "clamdscan"
   dashboard_api_key: "vigilion"
+  engines:
+    clamav: "clamdscan"
+    avg: "avgscan"
+    eset: "esets_scan"
 
 test:
   <<: *default
-  av_engine: "clamdscan"
   dashboard_api_key: "vigilion"
+  engines:
+    clamav: "clamdscan"
+    avg: "avgscan"
+    eset: "esets_scan"
 
 staging:
   <<: *default
-  av_engine: <%= ENV["AVENGINE"] %>
   dashboard_api_key:  <%= ENV["DASHBOARD_API_KEY"] %>
+  engines:
+    clamav: <%= ENV["CLAMAV_COMMAND"] %>
+    avg: <%= ENV["AVG_COMMAND"] %>
+    eset: <%= ENV["ESET_COMMAND"] %>
 
 production:
   <<: *default
-  av_engine: <%= ENV["AVENGINE"] %>
   dashboard_api_key:  <%= ENV["DASHBOARD_API_KEY"] %>
+  engines:
+    clamav: <%= ENV["CLAMAV_COMMAND"] %>
+    avg: <%= ENV["AVG_COMMAND"] %>
+    eset: <%= ENV["ESET_COMMAND"] %>

--- a/db/migrate/20160816121534_add_multiple_av_scanners_fields_to_scans.rb
+++ b/db/migrate/20160816121534_add_multiple_av_scanners_fields_to_scans.rb
@@ -1,0 +1,11 @@
+class AddMultipleAvScannersFieldsToScans < ActiveRecord::Migration[5.0]
+  def change
+    add_column :scans, :clamav_status, :integer, default: 0
+    add_column :scans, :eset_status, :integer, default: 0
+    add_column :scans, :avg_status, :integer, default: 0
+
+    add_column :scans, :clamav_result, :string
+    add_column :scans, :eset_result, :string
+    add_column :scans, :avg_result, :string
+  end
+end

--- a/db/migrate/20160816121558_add_multiple_av_scanners_fields_to_plans.rb
+++ b/db/migrate/20160816121558_add_multiple_av_scanners_fields_to_plans.rb
@@ -1,0 +1,7 @@
+class AddMultipleAvScannersFieldsToPlans < ActiveRecord::Migration[5.0]
+  def change
+    add_column :plans, :clamav, :boolean, default: true
+    add_column :plans, :eset, :boolean, default: false
+    add_column :plans, :avg, :boolean, default: false
+  end
+end

--- a/db/migrate/20160831173616_set_existing_scans_to_default.rb
+++ b/db/migrate/20160831173616_set_existing_scans_to_default.rb
@@ -1,0 +1,15 @@
+class SetExistingScansToDefault < ActiveRecord::Migration[5.0]
+  def up
+    say_with_time "set all existing scans to clamav by default" do
+      Scan.find_each do |scan|
+        scan.clamav_status = scan.status
+        scan.clamav_result = scan.result
+        scan.save
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "all scans have already been set to clamav!"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160423220851) do
+ActiveRecord::Schema.define(version: 20160831173616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,9 +29,12 @@ ActiveRecord::Schema.define(version: 20160423220851) do
     t.decimal  "cost"
     t.decimal  "file_size_limit"
     t.integer  "scans_per_month"
-    t.boolean  "available_for_new_subscriptions", default: true, null: false
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
+    t.boolean  "available_for_new_subscriptions", default: true,  null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.boolean  "clamav",                          default: true
+    t.boolean  "eset",                            default: false
+    t.boolean  "avg",                             default: false
   end
 
   create_table "projects", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -46,20 +49,26 @@ ActiveRecord::Schema.define(version: 20160423220851) do
   end
 
   create_table "scans", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "project_id",                 null: false
+    t.uuid     "project_id",                    null: false
     t.string   "url"
-    t.string   "key",                        null: false
-    t.boolean  "force",      default: false
-    t.integer  "status",     default: 0
+    t.string   "key",                           null: false
+    t.boolean  "force",         default: false
+    t.integer  "status",        default: 0
     t.string   "result"
     t.string   "md5"
     t.string   "sha1"
     t.string   "sha256"
     t.bigint   "file_size"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.datetime "started_at"
     t.datetime "ended_at"
+    t.integer  "clamav_status", default: 0
+    t.integer  "eset_status",   default: 0
+    t.integer  "avg_status",    default: 0
+    t.string   "clamav_result"
+    t.string   "eset_result"
+    t.string   "avg_result"
     t.index ["md5"], name: "index_scans_on_md5", using: :btree
     t.index ["project_id"], name: "index_scans_on_project_id", using: :btree
   end

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -196,6 +196,12 @@ RSpec.describe ScansController, type: :controller do
           expect(json["status"]).to eq "pending"
           expect(response).to have_http_status(:created)
         end
+
+        it "includes list of AV engines" do
+          post :create, params: { scan: valid_attributes }
+          json = JSON.parse(response.body)
+          expect(json["engines"]).to include("clamav")
+        end
       end
     end
 

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     cost 9.99
     file_size_limit 1
     scans_per_month 1
+    clamav true
 
     trait :no_scans_limit do
       scans_per_month nil

--- a/spec/services/av_runner/clamav_spec.rb
+++ b/spec/services/av_runner/clamav_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "open3"
+
+RSpec.describe AvRunner::Clamav do
+  describe "#perform!" do
+    before do
+      mock_clamavscan
+    end
+
+    after do
+      scan.delete_file
+    end
+
+    let(:scan) { create :scan, file: OpenStruct.new(read: "something") }
+    let(:avscan_response) { OpenStruct.new }
+    let(:result) { AvRunner::Clamav.new(scan).perform! }
+
+    context "with exitstatus=0" do
+      it "returns clean result" do
+        expect(result).to eq(status: :clean, message: "Stubbed Result")
+      end
+    end
+
+    context "with exitstatus=1" do
+      before { avscan_response.value.exitstatus = 1 }
+
+      it "marks scan as infected" do
+        expect(result).to eq(status: :infected, message: "Stubbed Result")
+      end
+    end
+
+    context "with exitstatus=2" do
+      before { avscan_response.value.exitstatus = 2 }
+
+      it "marks scan as error" do
+        expect(result).to eq(status: :error, message: "Stubbed Result")
+     end
+    end
+
+    def mock_clamavscan
+      avscan_response.value = OpenStruct.new
+      avscan_response.value.exitstatus = 0
+      stdout = OpenStruct.new
+      stdout.read = "Stubbed Result"
+      expect(Open3).to receive(:popen3).and_yield(nil, stdout, nil, avscan_response)
+    end
+  end
+end

--- a/spec/services/av_runner_spec.rb
+++ b/spec/services/av_runner_spec.rb
@@ -1,75 +1,17 @@
 require "rails_helper"
-require "open3"
 
 RSpec.describe AvRunner do
   describe "#perform" do
-    before do
-      mock_avscan
-    end
+    it "sends scanning requests to corrseponding classes" do
+      plan = create(:plan, clamav: true, eset: false, avg: false)
+      account = create(:account, plan: plan)
+      scan = create(:scan, account: account, file: OpenStruct.new(read: "something"))
 
-    after do
-      scan.delete_file
-    end
+      clamav = double
+      expect(clamav).to receive(:perform!).and_return({})
+      expect(AvRunner::Clamav).to receive(:new).with(scan).and_return(clamav)
 
-    let(:scan) { create :scan, file: OpenStruct.new(read: "something") }
-    let(:avscan_response) { OpenStruct.new }
-
-    context "with exitstatus=0" do
-      it "marks scan as clean" do
-        AvRunner.new.perform(scan)
-        expect(scan).to be_clean
-        expect(scan.result).to eq("Stubbed Result")
-      end
-    end
-
-    context "with exitstatus=1" do
-      before { avscan_response.value.exitstatus = 1 }
-
-      it "marks scan as infected" do
-        AvRunner.new.perform(scan)
-        expect(scan).to be_infected
-      end
-    end
-
-    context "with exitstatus=2" do
-      before { avscan_response.value.exitstatus = 2 }
-
-      it "marks scan as error" do
-        AvRunner.new.perform(scan)
-        expect(scan).to be_error
-      end
-    end
-
-    context "performing a new scan over the same file" do
-      before do
-        AvRunner.new.perform(scan)
-      end
-
-      after do
-        Scan.destroy_all
-      end
-
-      it "avoids scanning twice" do
-        expect(Open3).not_to receive(:popen3)
-        AvRunner.new.perform(create(:scan, file: scan.file))
-        expect(scan).to be_clean
-      end
-
-      context "with forced scan" do
-        it "performs the scan again" do
-          mock_avscan
-          AvRunner.new.perform(create(:scan, file: scan.file, force: true))
-          expect(scan).to be_clean
-        end
-      end
-    end
-
-    def mock_avscan
-      avscan_response.value = OpenStruct.new
-      avscan_response.value.exitstatus = 0
-      stdout = OpenStruct.new
-      stdout.read = "Stubbed Result"
-      expect(Open3).to receive(:popen3).and_yield(nil, stdout, nil, avscan_response)
+      described_class.new.perform(scan)
     end
   end
 end

--- a/spec/workers/scan_worker_spec.rb
+++ b/spec/workers/scan_worker_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe ScanWorker do
         scan = create(:scan, file: OpenStruct.new(read: "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"))
         puts scan.id
         ScanWorker.new.perform(scan.id)
-        expect(scan.reload).to be_infected
+        expect(scan.reload).to be_clamav_infected
+        expect(scan).to be_infected
+        expect(scan.result).to eq(scan.clamav_result)
       end
     end
 
@@ -24,7 +26,9 @@ RSpec.describe ScanWorker do
         scan = create(:scan, file: OpenStruct.new(read: "regular file"))
         puts scan.id
         ScanWorker.new.perform(scan.id)
-        expect(scan.reload).to be_clean
+        expect(scan.reload).to be_clamav_clean
+        expect(scan).to be_clean
+        expect(scan.result).to eq(scan.clamav_result)
       end
     end
   end


### PR DESCRIPTION
- account's plan has the scanners allowed
- scan can be run in different AVs - each analysis result is stored
- add a migration to set all existing scans to clamav (as it's the default)
- include AV engines for the scans in API response
- set status to infected if any of the AVs says so - and pick the infected result as the main status and result for the scan
