### PR TITLE
accept encoded URLs when creating scans

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'typhoeus'
 gem 'dotenv-rails'
 gem 'puma'
 gem 'sentry-raven'
+gem 'addressable', '~> 2.5'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.1)
     builder (3.2.2)
     byebug (9.0.5)
@@ -86,6 +88,7 @@ GEM
       pkg-config (~> 1.1.7)
     pg (0.18.4)
     pkg-config (1.1.7)
+    public_suffix (2.0.5)
     puma (3.6.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -172,6 +175,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.5)
   byebug
   database_cleaner
   dotenv-rails

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -17,6 +17,11 @@ class Scan < ActiveRecord::Base
   after_create :write_file
   before_destroy :delete_file
 
+  def url=(new_url)
+    unescaped_url = Addressable::URI.unescape(new_url)
+    write_attribute :url, unescaped_url
+  end
+
   def duration
     ended_at - started_at if ended_at
   end

--- a/spec/controllers/scans_controller_spec.rb
+++ b/spec/controllers/scans_controller_spec.rb
@@ -126,6 +126,21 @@ RSpec.describe ScansController, type: :controller do
           post :create, params: { scan: valid_attributes }
           expect(response).to be_created
         end
+
+        it "accepts an encoded URI" do
+          attributes = attributes_for(:scan, url: "https%3A%2F%2Fs3.amazonaws.com%2Fvigilion-load-test%2Feicar.com")
+          post :create, params: { scan: attributes }
+          expect(
+            JSON.parse(response.body)["url"]
+          ).to eq(valid_attributes[:url])
+        end
+
+        it "accepts a non-encoded URI" do
+          post :create, params: { scan: valid_attributes }
+          expect(
+            JSON.parse(response.body)["url"]
+          ).to eq(valid_attributes[:url])
+        end
       end
 
       context "with a scan not allowed to the account" do


### PR DESCRIPTION
related to a hotfix merged in #36 