### PR TITLE
raise scanning exceptions

### DIFF
--- a/app/services/scan_service.rb
+++ b/app/services/scan_service.rb
@@ -1,17 +1,12 @@
 class ScanService
   def perform(scan)
     return unless scan.pending?
-    begin
-      scan.start!
-      if FileDownloader.new.download scan
-        AvRunner.new.perform scan
-      end
-    rescue => ex
-      Sidekiq.logger.error ex
-      Sidekiq.logger.error ex.backtrace.join("\n")
-    ensure
-      scan.delete_file
-      ClientNotifier.new.notify scan
+
+    scan.start!
+    if FileDownloader.new.download scan
+      AvRunner.new.perform scan
     end
+    scan.delete_file
+    ClientNotifier.new.notify scan
   end
 end

--- a/spec/services/scan_service_spec.rb
+++ b/spec/services/scan_service_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe ScanService do
           scan_service.perform scan
         end
       end
+
+      context "when an exception occurs" do
+        before do
+          expect_any_instance_of(FileDownloader).to receive(:download).and_raise(RuntimeError)
+        end
+
+        it "does not call #delete_file and exceptions are raised" do
+          expect(scan).to_not receive(:delete_file)
+          expect {
+            scan_service.perform scan
+          }.to raise_exception(RuntimeError)
+        end
+      end
     end
 
     context "with non pending scan" do


### PR DESCRIPTION
stop sidekiq from swallowing exceptions and therefore jobs. Raise exceptions so these jobs are captured by sentry and retried later