### PR TITLE
alert account’s email address on 90% quota usage

### DIFF
--- a/app/mailers/account_quota_usage_mailer.rb
+++ b/app/mailers/account_quota_usage_mailer.rb
@@ -3,7 +3,16 @@ class AccountQuotaUsageMailer < ApplicationMailer
     @account = account
     mail(
       to: "support@vigilion.com",
-      subject: "High quota usage for account #{@account.id}"
+      subject: "High quota usage for account #{@account.name}"
+    )
+  end
+
+  def alert_client(account)
+    @account = account
+    @limit = @account.plan.scans_per_month
+    mail(
+      to: account.alert_email,
+      subject: "Your Vigilion API account #{@account.name} is now over 90%"
     )
   end
 end

--- a/app/services/account_quota_usage_analyser_service.rb
+++ b/app/services/account_quota_usage_analyser_service.rb
@@ -7,7 +7,8 @@ class AccountQuotaUsageAnalyserService
     end
   end
 
-  QUOTA_ALERT = 0.8 # 80%
+  QUOTA_CLIENT_ALERT = 0.9 # 90%
+  QUOTA_SUPPORT_ALERT = 0.8 # 80%
 
   def initialize(account:)
     @account = account
@@ -16,13 +17,26 @@ class AccountQuotaUsageAnalyserService
 
   def perform!
     return if unlimited_plan?
-    alert_amount = @plan.scans_per_month * QUOTA_ALERT
-    if @account.scan_amount_this_month >= alert_amount.to_i
+    alert_support!
+    alert_client!
+  end
+
+  private
+
+  def alert_support!
+    support_alert_amount = @plan.scans_per_month * QUOTA_SUPPORT_ALERT
+    if @account.scan_amount_this_month >= support_alert_amount.to_i
       AccountQuotaUsageMailer.alert_support(@account).deliver_later
     end
   end
 
-  private
+  def alert_client!
+    return if @account.alert_email.blank?
+    client_alert_amount = @plan.scans_per_month * QUOTA_CLIENT_ALERT
+    if @account.scan_amount_this_month >= client_alert_amount.to_i
+      AccountQuotaUsageMailer.alert_client(@account).deliver_later
+    end
+  end
 
   def unlimited_plan?
     @plan.scans_per_month.nil?

--- a/app/views/account_quota_usage_mailer/alert_client.text.erb
+++ b/app/views/account_quota_usage_mailer/alert_client.text.erb
@@ -1,0 +1,8 @@
+Hello,
+
+Your Vigilion API account for <%= @account.name %> is now over 90% of your monthly file limit of <%= @limit %>.
+
+Please contact support to increase your limit support@vigilion.com
+
+Kind Regards,
+Vigilion Team

--- a/app/views/account_quota_usage_mailer/alert_support.text.erb
+++ b/app/views/account_quota_usage_mailer/alert_support.text.erb
@@ -1,1 +1,1 @@
-The account <%= @account.id %> (with projects <%= @account.projects.map(&:name).join(", ") %>) has gone over 80% quota usage for this month
+The account <%= @account.name %> (with projects <%= @account.projects.map(&:name).join(", ") %>) has gone over 80% quota usage for this month

--- a/db/migrate/20170413130427_add_info_to_account.rb
+++ b/db/migrate/20170413130427_add_info_to_account.rb
@@ -1,0 +1,6 @@
+class AddInfoToAccount < ActiveRecord::Migration[5.0]
+  def change
+    add_column :accounts, :alert_email, :string
+    add_column :accounts, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160423220851) do
+ActiveRecord::Schema.define(version: 20170413130427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "accounts", force: :cascade do |t|
-    t.integer  "plan_id",                   null: false
-    t.boolean  "enabled",    default: true, null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.integer  "plan_id",                    null: false
+    t.boolean  "enabled",     default: true, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "alert_email"
+    t.string   "name"
     t.index ["plan_id"], name: "index_accounts_on_plan_id", using: :btree
   end
 

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :account do
     plan
+    sequence(:name) { |n| "account#{n}" }
+    alert_email { "#{name}@domain.com" }
   end
 end

--- a/spec/services/account_quota_usage_analyser_service_spec.rb
+++ b/spec/services/account_quota_usage_analyser_service_spec.rb
@@ -16,13 +16,35 @@ RSpec.describe AccountQuotaUsageAnalyserService do
     end
 
     context "when 80% usage is hit" do
-      before { create_list :scan, 8, project: account_project }
+      before do
+        ActionMailer::Base.deliveries.clear
+        create_list :scan, 8, project: account_project
+      end
 
-      it "an alert is triggered" do
+      it "one alert is triggered for support" do
         described_class.new(account: account).perform!
         email = ActionMailer::Base.deliveries.last
-        expect(email.subject).to include(account.id.to_s)
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+        expect(email.to).to eq(%w(support@vigilion.com))
+        expect(email.subject).to include(account.name)
         expect(email.body).to include(account_project.name)
+      end
+    end
+
+    context "when 90% usage is hit" do
+      before do
+        ActionMailer::Base.deliveries.clear
+        create_list :scan, 9, project: account_project
+      end
+
+      it "we alert the client **as well**" do
+        described_class.new(account: account).perform!
+        email = ActionMailer::Base.deliveries.last
+        expect(ActionMailer::Base.deliveries.count).to eq(2)
+        expect(email.to).to eq([account.alert_email])
+        expect(email.subject).to include(account.name)
+        expect(email.body).to include(account.name)
+        expect(email.body).to include("limit of #{plan.scans_per_month}")
       end
     end
   end


### PR DESCRIPTION
- add `name` and `email` to account so we can deliver an email alert notification and we use the name to identify the accounts