### PR TITLE
permit name & alert_email via api

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -43,6 +43,6 @@ class AccountsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def account_params
-      params.require(:account).permit(:plan_id, :enabled)
+      params.require(:account).permit(:plan_id, :enabled, :name, :alert_email)
     end
 end

--- a/app/views/accounts/show.json.jbuilder
+++ b/app/views/accounts/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @account, :id, :plan_id, :enabled, :created_at, :updated_at, :scan_amount_this_month
+json.extract! @account, :id, :plan_id, :enabled, :created_at, :updated_at, :scan_amount_this_month, :name, :alert_email


### PR DESCRIPTION
so dashboard admin can set these on accounts and we can alert support & clients from high quota usage