### PR TITLE
use new release for docker baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitzesty/vigilion-scanner-baseimage:latest
+FROM bitzesty/vigilion-scanner-baseimage:release-2.0
 
 # so that we sync in dev
 COPY . /usr/src/app


### PR DESCRIPTION
once release-2.0 has been built..

https://hub.docker.com/r/bitzesty/vigilion-scanner-baseimage/builds/bga4ui3wcjnevbtpormfvs8/

:shipit: 