### PR TITLE
add accounts:report_monthly_usage rake task

### DIFF
--- a/app/mailers/account_usage_mailer.rb
+++ b/app/mailers/account_usage_mailer.rb
@@ -1,0 +1,13 @@
+class AccountUsageMailer < ApplicationMailer
+  def monthly_usage(recipient, csv)
+    attachments['account_monthly.csv'] = {
+      content: csv,
+      mime_type: 'text/csv'
+    }
+    mail(
+      to: recipient,
+      subject: 'Monthly usage summary',
+      body: 'Find your summary attached'
+    )
+  end
+end

--- a/lib/account/report_monthly_usage_task.rb
+++ b/lib/account/report_monthly_usage_task.rb
@@ -1,0 +1,40 @@
+require "csv"
+
+class Account < ActiveRecord::Base
+  class ReportMonthlyUsageTask
+    def initialize(account_id:, recipient:)
+      @account = Account.find(account_id)
+      @recipient = recipient
+    end
+
+    def perform!
+      AccountUsageMailer.monthly_usage(@recipient, csv).deliver_now
+    end
+
+    def csv
+      CSV.generate do |csv|
+        csv << headers
+        @account.projects.each do |project|
+          csv << row_for(project)
+        end
+      end
+    end
+
+    def headers
+      months_str = months.map { |month| month.strftime("%b %Y") }
+      [ "project / number of scans per month" ].concat(months_str)
+    end
+
+    def months
+      time_range = @account.created_at.to_date..Date.today
+      months = time_range.map(&:beginning_of_month).uniq
+    end
+
+    def row_for(project)
+      month_values = months.map do |month|
+        project.scans.where(created_at: month.beginning_of_month..month.end_of_month).count
+      end
+      [ project.name ].concat(month_values)
+    end
+  end
+end

--- a/lib/tasks/accounts.rake
+++ b/lib/tasks/accounts.rake
@@ -1,3 +1,4 @@
+require "account/report_monthly_usage_task"
 require "account/resend_client_notifications_task"
 
 namespace :accounts do
@@ -6,6 +7,14 @@ namespace :accounts do
     Account::ResendClientNotificationsTask.new(
       account_id: ENV["ACCOUNT_ID"],
       date_from: ENV["DATE_FROM"]
+    ).perform!
+  end
+
+  desc "usage: accounts:report_monthly_usage ACCOUNT_ID=8 RECIPIENT=person@example.com"
+  task report_monthly_usage: :environment do
+    Account::ReportMonthlyUsageTask.new(
+      account_id: ENV["ACCOUNT_ID"],
+      recipient: ENV["RECIPIENT"]
     ).perform!
   end
 end


### PR DESCRIPTION
to send a CSV summary via email of the usage of all the projects within an account from it’s creation