### PR TITLE
use `logstash-event` gem & pin gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,19 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0.1'
-gem 'rake'
-gem 'pg'
+gem 'rake', '~> 11.2'
+gem 'pg', '~> 0.18'
 gem 'jbuilder', '~> 2.6.0'
-gem 'typhoeus'
-gem 'dotenv-rails'
-gem 'puma'
-gem 'sentry-raven'
+gem 'typhoeus', '~> 1.1'
+gem 'dotenv-rails', '~> 2.1'
+gem 'puma', '~> 3.6'
+gem 'sentry-raven', '~> 1.2'
 gem 'addressable', '~> 2.5'
 
 gem 'sidekiq', '~> 4.1'
 gem 'sidekiq-scheduler', '~> 2.0'
-gem 'lograge'
+gem 'lograge', '~> 0.5'
+gem 'logstash-event', '~> 1.2'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       actionpack (>= 4, < 5.2)
       activesupport (>= 4, < 5.2)
       railties (>= 4, < 5.2)
+    logstash-event (1.2.02)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -187,26 +188,27 @@ DEPENDENCIES
   addressable (~> 2.5)
   byebug
   database_cleaner
-  dotenv-rails
+  dotenv-rails (~> 2.1)
   factory_girl_rails
   jbuilder (~> 2.6.0)
-  lograge
-  pg
-  puma
+  lograge (~> 0.5)
+  logstash-event (~> 1.2)
+  pg (~> 0.18)
+  puma (~> 3.6)
   rails (~> 5.0.0.1)
   rails-controller-testing
-  rake
+  rake (~> 11.2)
   rspec-core (~> 3.5.0)
   rspec-expectations (~> 3.5.0)
   rspec-mocks (~> 3.5.0)
   rspec-rails (~> 3.5.0)
   rspec-support (~> 3.5.0)
-  sentry-raven
+  sentry-raven (~> 1.2)
   sidekiq (~> 4.1)
   sidekiq-scheduler (~> 2.0)
   simplecov
   timecop
-  typhoeus
+  typhoeus (~> 1.1)
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
should address:

```
2017-09-25T15:24:29Z web:RRJOZQOUGSS/3dff4aaeaae0 You need to install the logstash-event gem to use the logstash output.
2017-09-25T15:24:29Z web:RRJOZQOUGSS/3dff4aaeaae0 [caf6ab2c-2124-424f-b126-21824fbdab6d] Could not log "process_action.action_controller" event. LoadError: cannot load such file -- logstash-event ["/us
r/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `require'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `block in require
'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `
require'", "/usr/local/bundle/gems/lograge-0.5.1/lib/lograge/formatters/logstash.rb:13:in `load_dependencies'", "/usr/local/bundle/gems/lograge-0.5.1/lib/lograge/formatters/logstash.rb:5:in `call'", "/
usr/local/bundle/gems/lograge-0.5.1/lib/lograge/log_subscriber.rb:14:in `process_action'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/subscriber.rb:95:in `finish'", "/usr/local/bu
ndle/gems/activesupport-5.0.0.1/lib/active_support/log_subscriber.rb:83:in `finish'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/notifications/fanout.rb:102:in `finish'", "/usr/lo
cal/bundle/gems/activesupport-5.0.0.1/lib/active_support/notifications/fanout.rb:46:in `block in finish'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/notifications/fanout.rb:46:in
 `each'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/notifications/fanout.rb:46:in `finish'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/notifications/instru
menter.rb:42:in `finish_with_state'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/notifications/instrumenter.rb:27:in `instrument'", "/usr/local/bundle/gems/activesupport-5.0.0.1/l
ib/active_support/notifications.rb:164:in `instrument'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_controller/metal/instrumentation.rb:30:in `process_action'", "/usr/local/bundle/gems/actio
npack-5.0.0.1/lib/action_controller/metal/params_wrapper.rb:248:in `process_action'", "/usr/local/bundle/gems/activerecord-5.0.0.1/lib/active_record/railties/controller_runtime.rb:18:in `process_action
'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/abstract_controller/base.rb:126:in `process'", "/usr/local/bundle/gems/actionview-5.0.0.1/lib/action_view/rendering.rb:30:in `process'", "/usr/local/b
undle/gems/actionpack-5.0.0.1/lib/action_controller/metal.rb:190:in `dispatch'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_controller/metal.rb:262:in `dispatch'", "/usr/local/bundle/gems/ac
tionpack-5.0.0.1/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/routing/route_set.rb:32:in `serve'", "/usr/local/bundle/gems/
actionpack-5.0.0.1/lib/action_dispatch/journey/router.rb:39:in `block in serve'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/journey/router.rb:26:in `each'", "/usr/local/bundle/gems
/actionpack-5.0.0.1/lib/action_dispatch/journey/router.rb:26:in `serve'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/routing/route_set.rb:725:in `call'", "/usr/local/bundle/gems/rac
k-2.0.1/lib/rack/etag.rb:25:in `call'", "/usr/local/bundle/gems/rack-2.0.1/lib/rack/conditional_get.rb:25:in `call'", "/usr/local/bundle/gems/rack-2.0.1/lib/rack/head.rb:12:in `call'", "/usr/local/bund
le/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/callbacks.rb:38:in `block in call'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/callbacks.rb:97:in `__run_callbacks__'",
"/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/callbacks.rb:750:in `_run_call_callbacks'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/callbacks.rb:90:in `run_cal
lbacks'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/callbacks.rb:36:in `call'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/remote_ip.rb:79
:in `call'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/show_
exceptions.rb:31:in `call'", "/usr/local/bundle/gems/lograge-0.5.1/lib/lograge/rails_ext/rack/logger.rb:15:in `call_app'", "/usr/local/bundle/gems/railties-5.0.0.1/lib/rails/rack/logger.rb:24:in `block
 in call'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/tagged_logging.rb:70:in `block in tagged'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/tagged_logging.
rb:26:in `tagged'", "/usr/local/bundle/gems/activesupport-5.0.0.1/lib/active_support/tagged_logging.rb:70:in `tagged'", "/usr/local/bundle/gems/railties-5.0.0.1/lib/rails/rack/logger.rb:24:in `call'",
"/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/request_id.rb:24:in `call'", "/usr/local/bundle/gems/rack-2.0.1/lib/rack/runtime.rb:22:in `call'", "/usr/local/bundle/gems/acti
vesupport-5.0.0.1/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'", "/usr/local/bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/executor.rb:12:in `call'", "/usr/l
ocal/bundle/gems/rack-2.0.1/lib/rack/sendfile.rb:111:in `call'", "/usr/local/bundle/gems/sentry-raven-1.2.2/lib/raven/integrations/rack.rb:50:in `call'", "/usr/local/bundle/gems/railties-5.0.0.1/lib/ra
ils/engine.rb:522:in `call'", "/usr/local/bundle/gems/puma-3.6.0/lib/puma/configuration.rb:225:in `call'", "/usr/local/bundle/gems/puma-3.6.0/lib/puma/server.rb:578:in `handle_request'", "/usr/local/bu
ndle/gems/puma-3.6.0/lib/puma/server.rb:415:in `process_client'", "/usr/local/bundle/gems/puma-3.6.0/lib/puma/server.rb:275:in `block in run'", "/usr/local/bundle/gems/puma-3.6.0/lib/puma/thread_pool.r
b:116:in `block in spawn_thread'"]```