### PR TITLE
[codex] Upgrade vulnerable gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.3)
     e2mmap (0.1.0)
-    erb (6.0.3)
+    erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -114,6 +114,16 @@ GEM
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
     ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -150,7 +160,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
-    net-imap (0.4.23)
+    net-imap (0.4.24)
       date
       net-protocol
     net-pop (0.1.2)
@@ -160,10 +170,32 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
     pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -288,7 +320,19 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   addressable (~> 2.8)

--- a/app/services/file_downloader.rb
+++ b/app/services/file_downloader.rb
@@ -11,10 +11,7 @@ class FileDownloader
 private
 
   def download_file(scan)
-    if scan.file_path.include?("..") || scan.file_path.include?("/") || scan.file_path.include?("\\")
-      raise "Invalid path: path traversal detected in #{scan.file_path}"
-    end
-    downloaded_file = File.open scan.file_path, "wb"
+    downloaded_file = File.open validated_file_path(scan), "wb"
     request = Typhoeus::Request.new(scan.url, accept_encoding: "gzip", ssl_verifypeer: false, ssl_verifyhost: 0, followlocation: true)
     request.on_headers do |response|
       validate_status response
@@ -28,6 +25,17 @@ private
     end
     request.run
     true
+  end
+
+  def validated_file_path(scan)
+    tmp_path = Rails.root.join("tmp").to_s
+    file_path = File.expand_path(scan.file_path)
+
+    unless file_path.start_with?("#{tmp_path}/")
+      raise DownloadError.new "Invalid path"
+    end
+
+    file_path
   end
 
   def validate_status(response)

--- a/spec/services/file_downloader_spec.rb
+++ b/spec/services/file_downloader_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe FileDownloader do
           expect(file_content(scan)).to eq url_content
         end
       end
+
+      context "with a file path outside tmp" do
+        before do
+          allow(scan).to receive(:file_path).and_return(Rails.root.join("tmp", "..", "invalid.txt").to_s)
+        end
+
+        it "sets scan status to error" do
+          expect(downloader.download(scan)).to be false
+
+          scan.reload
+          expect(scan).to be_error
+          expect(scan.result).to eq("Cannot download file. Invalid path")
+        end
+      end
     end
 
     def mock_download_request(status = 200, content_length = 1000)


### PR DESCRIPTION
## Summary

- Upgrade patched versions of `erb`, `net-imap`, and `nokogiri` to address the open Dependabot security alerts.
- Normalize Bundler platforms so native gem variants are recorded consistently for supported runtime platforms.
- Fix the pulled `FileDownloader` path validation guard so generated absolute paths under `tmp/` are allowed while paths escaping `tmp/` are rejected.

## Root cause

The latest `main` already included an initial security baseline, but the lockfile still had older patched gems available. A recently added downloader traversal guard checked for path separators in the full absolute path, which caused every normal `Scan#file_path` under the app `tmp/` directory to fail.

## Validation

```text
RAILS_ENV=test DATABASE_URL=postgres://postgres:password@localhost:5432/vigilion_scanner_test bundle exec rspec
169 examples, 0 failures
```
